### PR TITLE
Inject app id suffix dynamically via env var or local.properties

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@
 name: pull-request
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 jobs:
   pull-request:
     runs-on: ubuntu-latest

--- a/showcase/build.gradle.kts
+++ b/showcase/build.gradle.kts
@@ -29,14 +29,12 @@ android {
         }
     }
 
-    val reccoClientSecretEnv: String? = System.getenv("RECCO_CLIENT_SECRET")
-    val reccoClientSecretLocalProperties: String? = gradleLocalProperties(rootDir).getProperty("recco.client.secret")
-    // Default to empty to avoid crashing the build when running status checks on Github Actions such as Lint
-    val clientSecret = reccoClientSecretEnv ?: reccoClientSecretLocalProperties ?: "\"\""
+    val appIdSuffix = resolveAppIdSuffix()
+    val clientSecret = resolveClientSecret()
 
     buildTypes {
         named("debug") {
-            applicationIdSuffix = ".debug"
+            applicationIdSuffix = ".$appIdSuffix"
 
             buildConfigField(
                 type = "String",
@@ -45,7 +43,10 @@ android {
             )
         }
 
+
         named("release") {
+            applicationIdSuffix = ".$appIdSuffix"
+
             isMinifyEnabled = true
             isShrinkResources = true
             setProguardFiles(
@@ -120,10 +121,12 @@ dependencies {
 
 easylauncher {
     buildTypes {
+        val appIdSuffix = resolveAppIdSuffix().uppercase()
+
         create("debug") {
             filters(
                 customRibbon(
-                    label = "DEBUG",
+                    label = appIdSuffix,
                     ribbonColor = "#FFf5b731",
                     labelColor = "#FFFFFF"
                 )
@@ -133,7 +136,7 @@ easylauncher {
         create("release") {
             filters(
                 customRibbon(
-                    label = "PROD",
+                    label = appIdSuffix,
                     ribbonColor = "#FF9EE4A1",
                     labelColor = "#FFFFFF"
                 )
@@ -142,3 +145,15 @@ easylauncher {
     }
 }
 
+fun resolveAppIdSuffix(): String {
+    val applicationIdSuffixEnv = System.getenv("RECCO_APP_ID_SUFFIX")
+    val applicationIdLocalProperties: String? = gradleLocalProperties(rootDir).getProperty("recco.app.id.suffix")
+    return applicationIdSuffixEnv ?: applicationIdLocalProperties ?: "dev"
+}
+
+fun resolveClientSecret(): String {
+    val reccoClientSecretEnv: String? = System.getenv("RECCO_CLIENT_SECRET")
+    val reccoClientSecretLocalProperties: String? = gradleLocalProperties(rootDir).getProperty("recco.client.secret")
+    // Default to empty to avoid crashing the build when running status checks on Github Actions such as Lint
+    return reccoClientSecretEnv ?: reccoClientSecretLocalProperties ?: "\"\""
+}


### PR DESCRIPTION
Related jira tickets 
* https://vilua.atlassian.net/browse/SHAD-324
* https://vilua.atlassian.net/browse/SHAD-323

This PR allows to inject via env var or local.properties the suffix of the package id. This is leverage from Bitrise workflows to build APKs with different application ids, and therefore, allowing the users to have 3 different APKs pointing each one of them to its specific BE environment counterpart.

I also updated the relevant confluence docs: https://vilua.atlassian.net/wiki/spaces/SHAD/pages/326369324/Android+-+Development+environments